### PR TITLE
Use ActiveMQ Artemis

### DIFF
--- a/docker/.env
+++ b/docker/.env
@@ -19,8 +19,8 @@ MONGO_URI='mongodb://localhost/diagnostic-modality-integration'
 ACTIVEMQ_PROTOCOL='mqtt'
 ACTIVEMQ_HOSTNAME='localhost'
 ACTIVEMQ_PORT=1883
-ACTIVEMQ_USERNAME=''
-ACTIVEMQ_PASSWORD=''
+ACTIVEMQ_USERNAME='artemis'
+ACTIVEMQ_PASSWORD='artemis'
 
 ########################################################################################################################
 # MYSQL

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -65,7 +65,7 @@ services:
     ports:
       - '3306:3306'
   activemq:
-    image: apache/activemq-artemis:latest
+    image: apache/activemq-artemis:2.44.0
     restart: unless-stopped
     environment:
       ARTEMIS_USER: artemis

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -65,14 +65,16 @@ services:
     ports:
       - '3306:3306'
   activemq:
-    image: rmohr/activemq
+    image: apache/activemq-artemis:latest
     restart: unless-stopped
-    env_file: .env
-    volumes:
-      - ./containers/activemq/data:/opt/activemq/data
+    environment:
+      ARTEMIS_USER: artemis
+      ARTEMIS_PASSWORD: artemis
     ports:
       - '1883:1883'
       - '8161:8161'
+    volumes:
+      - ./containers/activemq/data:/var/lib/artemis-instance
   redis:
     image: redis:6
     restart: unless-stopped


### PR DESCRIPTION
The old ActiveMQ server didn't not support shared subscriptions, which can be used to ensure that only one instance consumes a message for a single topic. The messages are distributed in a round-robin fashion.

ActiveMQ Artemis supports shared subscription. It also requires non-blank username and password.