### PR TITLE
Update Kubernetes ActiveMQ manifest to Artemis

### DIFF
--- a/kubernetes/dmi-dev/activemq.yaml
+++ b/kubernetes/dmi-dev/activemq.yaml
@@ -35,12 +35,16 @@ spec:
     spec:
       containers:
         - name: activemq
-          image: symptoma/activemq:latest
+          image: apache/activemq-artemis:2.44.0
+          env:
+            # Consumers in these manifests connect without credentials
+            - name: ANONYMOUS_LOGIN
+              value: 'true'
           ports:
             - containerPort: 1883
           volumeMounts:
             - name: storage
-              mountPath: /data/db
+              mountPath: /var/lib/artemis-instance
       volumes:
         - name: storage
           persistentVolumeClaim:


### PR DESCRIPTION
Closes #35

#34 swapped the broker to Artemis in `docker/docker-compose.yml` only; `kubernetes/dmi-dev/activemq.yaml` still deployed ActiveMQ Classic (`symptoma/activemq:latest`). Classic accepts `$share` subscriptions (used by the nominal-systems/dmi-api#292 application versions) but never delivers any message to them, so an environment spun up from this manifest would silently process no traffic.

Changes:
- `image`: `symptoma/activemq:latest` → `apache/activemq-artemis:2.44.0` (same pinned version as docker-compose)
- `ANONYMOUS_LOGIN=true`: the app manifests in `kubernetes/` connect without ActiveMQ credentials, so the broker must accept anonymous connections (the docker-compose setup uses artemis/artemis credentials instead, matching `docker/.env`)
- volume mount moved to `/var/lib/artemis-instance` (Artemis instance directory, as in #34)

Validation: YAML parses correctly (3 documents); `kubectl apply --dry-run=client` could not run because the current kubeconfig points to a private AKS endpoint not resolvable from this machine.