### PR TITLE
Document observation-level units field

### DIFF
--- a/spec/reference/schemas/Observation.yaml
+++ b/spec/reference/schemas/Observation.yaml
@@ -36,10 +36,18 @@ properties:
         type: number
         description: Numerical value of the result
         example: 10.0
-      unit:
+      units:
         type: string
         description: Unit of the result value
         example: g/dL
+  units:
+    type: string
+    description: |
+      Unit of the result value, at the observation level. Present whenever the
+      diagnostic provider reports a unit, regardless of whether the value is
+      numeric (`valueQuantity`) or textual (`valueString`). For numeric results
+      this duplicates `valueQuantity.units`; consumers should read `units` here.
+    example: g/dL
   media:
     type: array
     description: |


### PR DESCRIPTION
## What

Document the new observation-level `units` field on the `Observation` schema, and fix a pre-existing spec drift where `valueQuantity.unit` (singular) was documented while the code emits `units` (plural).

## Background

Part of nominal-systems/dmi-engine-antech-v6-integration#71. Provider integrations now emit a top-level `units` so that units survive for non-numeric results (`< 20`, `****`, …) that carry no `valueQuantity`. The spec needs to reflect it.

## Approach

- Add `units: string` at the observation level, with a description noting it is present whenever the provider reports a unit (numeric or textual value) and that for numeric results it duplicates `valueQuantity.units` — consumers should read the observation-level `units`.
- Correct `valueQuantity.unit` → `valueQuantity.units` to match the emitted payload.

## Safety

Documentation-only, additive. `swagger-cli validate` passes.

## Tests

`cd spec && npm run validate` → `reference/dmi.yaml is valid`.

Part of nominal-systems/dmi-engine-antech-v6-integration#71